### PR TITLE
Fix xbmc.translatePath not found in LE11

### DIFF
--- a/service.py
+++ b/service.py
@@ -34,8 +34,8 @@ msgdialogprogress = xbmcgui.DialogProgress()
 
 addon_id = 'service.fanshim'
 selfAddon = xbmcaddon.Addon(addon_id)
-datapath = xbmc.translatePath(selfAddon.getAddonInfo('profile'))
-addonfolder = xbmc.translatePath(selfAddon.getAddonInfo('path'))
+datapath = xbmcvfs.translatePath(selfAddon.getAddonInfo('profile'))
+addonfolder = xbmcvfs.translatePath(selfAddon.getAddonInfo('path'))
 
 
 


### PR DESCRIPTION
Kodi 20 (Nexus) no longer supports xbmc.translatepath.  Use xbmcvfs.translatepath instead.